### PR TITLE
Adds Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ install:
   # Force Spark's build/mvn to download and use its own recent version of maven
   - export FORCE_MVN=1
   - export SPARK_TEST_TAGS_EXCLUDED_DEFAULT=
-  - dev/criteo/build-with-maven.sh install
-  - dev/criteo/test-with-maven.sh
+  - travis_wait 10 dev/criteo/build-with-maven.sh -B -q install
+  - travis_wait 20 dev/criteo/test-with-maven.sh -B -q
 
 # 6. Run lint-java.
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Spark provides this Travis CI configuration file to help contributors
+# check Scala/Java style conformance and JDK7/8 compilation easily
+# during their preparing pull requests.
+#   - Scalastyle is executed during `maven install` implicitly.
+#   - Java Checkstyle is executed by `lint-java`.
+# See the related discussion here.
+# https://github.com/apache/spark/pull/12980
+
+# 1. Choose OS (Ubuntu 14.04.3 LTS Server Edition 64bit, ~2 CORE, 7.5GB RAM)
+sudo: required
+dist: trusty
+
+# 2. Choose language and target JDKs for parallel builds.
+language: java
+jdk:
+  - oraclejdk8
+
+# 3. Setup cache directory for SBT and Maven.
+cache:
+  directories:
+  - $HOME/.sbt
+  - $HOME/.m2
+
+# 4. Turn off notifications.
+notifications:
+  email: false
+
+# 5. Run maven install before running lint-java.
+# CRITEO SPECIFIC DO NOT MERGE UPSTREAM
+install:
+  - export MAVEN_SKIP_RC=1
+  # Force Spark's build/mvn to download and use its own recent version of maven
+  - export FORCE_MVN=1
+  - export SPARK_TEST_TAGS_EXCLUDED_DEFAULT=
+  - dev/criteo/build-with-maven.sh install
+  - dev/criteo/test-with-maven.sh
+
+# 6. Run lint-java.
+script:
+  - dev/lint-java

--- a/dev/criteo/README.md
+++ b/dev/criteo/README.md
@@ -1,0 +1,17 @@
+## Criteo specific developer's scripts ##
+
+This directory holds a bunch of script intended for contributing to Spark from the Criteo environment. 
+The content of this directory *is not to be contributed upstream*.
+
+### Local compilation and testing ###
+
+* criteo-spark-env.sh: to be *sourc'ed* by other scrip to provide consistent configuration
+* build-with-maven.sh: package Spark using *the right* (really?) options for the Criteo build of Spark. 
+  Additional argument can be passed, they will be forwarded to maven. Tests **are skipped**.
+* test-with-maven.sh: launch Spark unit testing with options for the Criteo build of Spark. 
+  Additional argument can be passed, they will be forwarded to maven. Most useful one are
+  
+  ```
+  ./dev/criteo/build-with-maven -pl mllib # Run tesst only for one maven module
+  ./dev/criteo/build-with-maven -Dtest=Those*TesSuite,!ButNotThiOne # Select tests
+  ```

--- a/dev/criteo/build-with-maven.sh
+++ b/dev/criteo/build-with-maven.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source `dirname "$0"`/criteo-spark-env.sh
+
+$SPARK_HOME/build/mvn -T 1C $CRITEO_SPARK_PROFILES -DskipTests "${@:-package}"

--- a/dev/criteo/criteo-spark-env.sh
+++ b/dev/criteo/criteo-spark-env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export SPARK_HOME="$(cd "`dirname "$0"`"; cd ../..; pwd)"
+
+export CRITEO_HADOOP_VERSION=2.6.0-cdh5.5.0
+
+export CRITEO_SPARK_PROFILES="-Pyarn -Phadoop-2.6 -Dhadoop.version=$CRITEO_HADOOP_VERSION -Phive -Phive-thriftserver"

--- a/dev/criteo/make-criteo-distribution.sh
+++ b/dev/criteo/make-criteo-distribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-SPARK_HOME="$(cd "`dirname "$0"`"; cd ../..; pwd)"
+source `dirname "$0"`/criteo-spark-env.sh
 
-$SPARK_HOME/make-distribution.sh --name criteo --tgz -Pyarn -Phadoop-2.6 -Dhadoop.version=2.6.0-cdh5.5.0 -Phive -Phive-thriftserver
+$SPARK_HOME/make-distribution.sh --name criteo --tgz $CRITEO_SPARK_PROFILES

--- a/dev/criteo/test-with-maven.sh
+++ b/dev/criteo/test-with-maven.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# You can run tests for a module only by specifying -pl <module>
+# as argument to this script, or some specific test by passing
+# -Dtest=... (see surefire documentation).
+
+source `dirname "$0"`/criteo-spark-env.sh
+
+export _JAVA_OPTIONS="-Xss2048k -Dspark.buffer.pageSize=1048576 -Xmx4g"
+
+SPARK_TEST_TAGS_EXCLUDED=org.apache.spark.tags.DockerTest
+
+$SPARK_HOME/build/mvn $CRITEO_SPARK_PROFILES                                   \
+    -Dtest.exclude.tags=$SPARK_TEST_TAGS_EXCLUDED                              \
+    -DfailIfNoTests=false --fail-at-end                                        \
+    test "$@"

--- a/dev/criteo/test-with-maven.sh
+++ b/dev/criteo/test-with-maven.sh
@@ -8,7 +8,8 @@ source `dirname "$0"`/criteo-spark-env.sh
 
 export _JAVA_OPTIONS="-Xss2048k -Dspark.buffer.pageSize=1048576 -Xmx4g"
 
-SPARK_TEST_TAGS_EXCLUDED=org.apache.spark.tags.DockerTest
+SPARK_TEST_TAGS_EXCLUDED_DEFAULT=org.apache.spark.tags.DockerTest
+SPARK_TEST_TAGS_EXCLUDED=${SPARK_TEST_TAGS_EXCLUDED-${SPARK_TEST_TAGS_EXCLUDED_DEFAULT}}
 
 $SPARK_HOME/build/mvn $CRITEO_SPARK_PROFILES                                   \
     -Dtest.exclude.tags=$SPARK_TEST_TAGS_EXCLUDED                              \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Back-port Spark 2 Travis configuration and adapt it to Criteo configuration.
